### PR TITLE
white screen issue on fb login page fixed

### DIFF
--- a/phonegap.facebook.inappbrowser.js
+++ b/phonegap.facebook.inappbrowser.js
@@ -166,7 +166,14 @@
                 },
                 userDenied = false;
 
-            faceView = window.open(authorize_url, '_blank', 'location=no');
+            //faceView = window.open(authorize_url, '_blank', 'location=no');
+            //modified by jcoltrane to hide the window because a white page is shown till the fb login page is actually loaded - hidden=yes added
+            faceView = window.open(authorize_url, '_blank', 'location=no,hidden=yes');
+            //we now have to listen to loadstop so we show the window once the page is loaded
+            faceView.addEventListener('loadstop', function(){
+												faceView.show();		
+										});
+            //finished changes by jcoltrane to reduce white page shown on facebook login page load
             faceView.addEventListener('loadstart', callback);
             faceView.addEventListener('exit', function() {
 


### PR DESCRIPTION
The prolonged white screen shown on android while the fb login page is loading has been eliminated for all but the very first install/invocation of the page. This fix tested on android (but likely will work on iOS ..since the phonegap InAppBrowser hidden window is available only on Android and iOS).
