### PR TITLE
Sharing openg graph actions (like likes) require different endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ FacebookInAppBrowser.share({
 	    alert('success');
     }
 });
+// please note that you could get errors like:
+// "User is already associated to the object type, article, on a unique action..."
+// if you try to re-like something already liked by the user
 
 // Logout
 FacebookInAppBrowser.logout(function() {

--- a/phonegap.facebook.inappbrowser.js
+++ b/phonegap.facebook.inappbrowser.js
@@ -408,6 +408,9 @@
 
         /**
          * Open Share dialog
+         *
+         * Let you use the Share Dialog https://developers.facebook.com/docs/sharing/reference/share-dialog
+         *
          * @param  {Object}   data either with "href" key or "action_type", "action_properties" keys
          * @param  {Function} afterCallback Success/Error callback, will receive false on error, true or the created object_id on success
          */
@@ -457,11 +460,12 @@
                             }, 0);
                         }
 
-                    } else if (location.url.indexOf('?object_id=') !== -1) {
+                    } else if (location.url.indexOf('?post_id=') !== -1
+                        || location.url.indexOf('?object_id=') !== -1) { // according to the docs, the parameter should be called object_id, however facebook uses post_id too
                         // Success
                         faceView.close();
 
-                        var object_id = location.url.match(/object_id=([^#]+)/)[1];
+                        var object_id = location.url.match(/(post|object)_id=([^#]+)/)[2];
 
                         if (FacebookInAppBrowser.exists(afterCallback, 'function')) {
                             setTimeout(function() {


### PR DESCRIPTION
I've realized that I've forgot to handle the case when you are using the share dialog to share an open graph action (like the "like"). This kind of share uses a different endpoint. 
This patch fixes this and adds an example to the README and also fixes some other typos I've made before.
