### PR TITLE
Corrected the typo error

### DIFF
--- a/phonegap.facebook.inappbrowser.js
+++ b/phonegap.facebook.inappbrowser.js
@@ -245,7 +245,7 @@
                 return false;
             }
 
-            var get_url  = "https://graph.facebook.com/me?fields=email,name,gender&access_token=" + window.localStorage.getItem('accessToken');
+            var get_url  = "https://graph.facebook.com/me?fields=email,name,gender&access_token=" + window.localStorage.getItem('facebookAccessToken');
             console.log('[FacebookInAppBrowser] getInfo request url: ' + get_url);
 
             FacebookInAppBrowser.ajax('GET', get_url, function(data) {


### PR DESCRIPTION
"accessToken" key was used to get access token from the localstorage while it must be "facebookAccessToken" at line 248
